### PR TITLE
Feature integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 .tempdir/
 reports/
 test_report.html
+integration_test_report.html

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Make sure you have setup the project properly before running the tests, see abov
 #### How to run integration test cases
 1. `.env` file is required for Unit test cases.
 2. To run the integration test cases, run the below command
-   `python -m unittest tests/integration_tests/test_gtfs_pathways_integration.py`
+   1. `python test_integration.py`
+   2. Above command will run all integration test cases and generate the html report, in `reports` folder at the root level.
 
 
 ### Messaging

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Make sure you have setup the project properly before running the tests, see abov
       2. Above command will generate the html report, and generated html would be in `htmlcov` directory at the root level.
    5. _NOTE :_ To run the `html` or `report` coverage, 3.i) command is mandatory
 
+#### How to run integration test cases
+1. `.env` file is required for Unit test cases.
+2. To run the integration test cases, run the below command
+   `python -m unittest tests/integration_tests/test_gtfs_pathways_integration.py`
+
+
 ### Messaging
 
 This microservice deals with two topics/queues. 

--- a/test-case-enumeration.md
+++ b/test-case-enumeration.md
@@ -89,3 +89,14 @@ if __name__ == '__main__':
 | Server | TestApp | Functional | When calling get_settings function | Expect to return env variables |:white_check_mark:|
 | Server | TestApp | Functional | When calling ping function | Expect to return 200 |:white_check_mark:|
 | Server | TestApp | Functional | When calling root function | Expect to return 200 |:white_check_mark:|
+
+
+## Integration Test cases
+In case of integration tests, the system will look for all the integration points to be tested
+
+| Component | Feature under test | Scenario | Expectation | Status |
+|-|-|-|-|-|
+| Pathways Validator | Servicebus integration | Subscribe to upload topic to verify servicebus integration | Expect to return message |:white_check_mark: |
+| Pathways Validator | Servicebus integration | Should publish a message to be received on topic | Expect to receive message on target topic | :white_check_mark: |
+| Pathways Validator | Storage Integration | Fetching a file returns a file entity | Expect to return the file entity | |
+

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,22 @@
+import unittest
+import HtmlTestRunner
+
+# Define your test cases
+from tests.integration_tests.test_gtfs_pathways_integration import TestGTFSPathwaysIntegration
+
+if __name__ == '__main__':
+    # Create a test suite
+    test_suite = unittest.TestSuite()
+    # Add your test cases to the test suite
+    test_suite.addTest(unittest.makeSuite(TestGTFSPathwaysIntegration))
+
+    # Define the output file for the HTML report
+    output_file = 'integration_test_report.html'
+
+    # Open the output file in write mode
+    with open(output_file, 'w') as f:
+        # Create an HTMLTestRunner instance with the output file and customize the template
+        runner = HtmlTestRunner.HTMLTestRunner(stream=f, report_title='Integration Test Report', combine_reports=True)
+
+        # Run the test suite with the HTMLTestRunner
+        runner.run(test_suite)

--- a/tests/integration_tests/test_gtfs_pathways_integration.py
+++ b/tests/integration_tests/test_gtfs_pathways_integration.py
@@ -1,0 +1,29 @@
+from src.config import Settings
+from src.gtfx_pathways_validator import GTFSPathwaysValidator
+from python_ms_core import Core
+
+class TestGTFSPathwaysIntegration(unittest.TestCase):
+    def setUp(self):
+        print('hello')
+        this.settings = Settings()
+        this.settings.subscription_topic_name = ''
+        this.settings.subscription_name = ''
+        this.settings.validation_topic = ''
+        this.core = Core()
+        
+
+    def test_servicebus_receive(self):
+        print('Have to test receiving of service bus')
+        # create a gtfs_pathways_validator object
+        gtfs_pathways_validator = GTFSPathwaysValidator()
+        # Mock the listening and subscribe method
+
+        topic = this.core.get_topic(this.settings.subscription_topic_name)
+        # post a message to this topic
+        msg = QueueMessage() # fill content for message
+        topic.publish(msg)
+        # Check if the message is received by gtfs_pathways_validator in 
+        # the mocked method
+
+    def test_servicebus_post(self):
+        print('Have to test if the service can post')

--- a/tests/integration_tests/test_gtfs_pathways_integration.py
+++ b/tests/integration_tests/test_gtfs_pathways_integration.py
@@ -1,29 +1,83 @@
-from src.config import Settings
+import unittest
+import os
+import json
+import time
+from unittest.mock import patch, MagicMock
+from dotenv import load_dotenv
+import asyncio
+from urllib.parse import urlparse
+
+# Execute to apply environment variable overrides
+load_dotenv()
+
+os.environ['UPLOAD_TOPIC'] = 'temp-upload'
+os.environ['UPLOAD_SUBSCRIPTION'] = 'upload-validation-processor'
+os.environ['VALIDATION_TOPIC'] = 'temp-validation'
+
 from src.gtfx_pathways_validator import GTFSPathwaysValidator
 from python_ms_core import Core
+from python_ms_core.core.queue.models.queue_message import QueueMessage
+
+TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEST_JSON_FILE = os.path.join(TEST_DIR, 'test_harness/test_files/pathways_test_case2.json')
+
 
 class TestGTFSPathwaysIntegration(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.core = Core()
+        cls.upload_topic_name = os.environ['UPLOAD_TOPIC']
+        cls.upload_subscription_name = os.environ['UPLOAD_SUBSCRIPTION']
+        cls.validation_topic_name = os.environ['VALIDATION_TOPIC']
+
     def setUp(self):
-        print('hello')
-        this.settings = Settings()
-        this.settings.subscription_topic_name = ''
-        this.settings.subscription_name = ''
-        this.settings.validation_topic = ''
-        this.core = Core()
-        
+        self.test_data = self.read_test_data()
 
-    def test_servicebus_receive(self):
-        print('Have to test receiving of service bus')
-        # create a gtfs_pathways_validator object
-        gtfs_pathways_validator = GTFSPathwaysValidator()
-        # Mock the listening and subscribe method
+    @staticmethod
+    def read_test_data():
+        with open(TEST_JSON_FILE, 'r') as test_file:
+            test_data = json.loads(test_file.read())
+        return test_data
 
-        topic = this.core.get_topic(this.settings.subscription_topic_name)
-        # post a message to this topic
-        msg = QueueMessage() # fill content for message
-        topic.publish(msg)
-        # Check if the message is received by gtfs_pathways_validator in 
-        # the mocked method
+    def tearDown(self):
+        pass
 
-    def test_servicebus_post(self):
-        print('Have to test if the service can post')
+    @patch.object(GTFSPathwaysValidator, 'subscribe', new=MagicMock())
+    def test_subscribe_to_upload_topic(self):
+        if os.environ['QUEUECONNECTION'] is None:
+            self.fail('QUEUECONNECTION environment not set')
+        validator = GTFSPathwaysValidator()
+        upload_topic = self.core.get_topic(topic_name=self.upload_topic_name)
+        message = QueueMessage.data_from({'message': '', 'data': self.test_data})
+        upload_topic.publish(data=message)
+        time.sleep(0.5)  # Wait to get the callback
+        validator.subscribe.assert_called_once()
+
+    @patch.object(GTFSPathwaysValidator, 'subscribe', new=MagicMock())
+    async def test_servicebus_receive(self):
+        if os.environ['QUEUECONNECTION'] is None:
+            self.fail('QUEUECONNECTION environment not set')
+        validator = GTFSPathwaysValidator()
+        subscribe_function = MagicMock()
+        message = QueueMessage.data_from({'message': '', 'data': self.test_data})
+        validator.publish_topic.publish(data=message)
+        validation_topic = self.core.get_topic(topic_name=self.validation_topic_name)
+        async with validation_topic.subscribe(subscription='temp-validation-result', callback=subscribe_function):
+            await asyncio.sleep(0.5)  # Wait for callback
+            subscribe_function.assert_called_once()
+            validator.subscribe.assert_called_once()
+
+    def test_file_entity(self):
+        test_file_url = 'https://tdeisamplestorage.blob.core.windows.net/osw/2023/APRIL/66c85a5a-2335-4b97-a0a3-0bb93cba1ae5/osw-test-upload_19df12452cae4da5a71db3fa276f4f5e.zip'
+        url = urlparse(test_file_url)
+        file_path = url.path
+        file_components = file_path.split('/')
+        container_name = file_components[1]
+        file = self.core.get_storage_client().get_file_from_url(container_name=container_name, full_url=test_file_url)
+        content = file.get_stream()
+        self.assertTrue(content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Added integration test cases**

There are 3 test cases for integration - 

1. test_subscribe_to_upload_topic
2. test_servicebus_receive
3. test_file_entity

**How to run integration tests**
`python test_integration.py`


Above command will generate the html file `integration_test_report.html` at root level, containing -
```

Running tests... 
----------------------------------------------------------------------
 test_file_entity (tests.integration_tests.test_gtfs_pathways_integration.TestGTFSPathwaysIntegration) ... OK (16.887071)s
 test_servicebus_receive (tests.integration_tests.test_gtfs_pathways_integration.TestGTFSPathwaysIntegration) ... OK (0.013860)s
 test_subscribe_to_upload_topic (tests.integration_tests.test_gtfs_pathways_integration.TestGTFSPathwaysIntegration) ... OK (9.552038)s

----------------------------------------------------------------------
Ran 3 tests in 0:00:26

OK



Generating HTML reports... 
reports/TestResults_TestGTFSPathwaysIntegration_2023-08-08_16-54-41.html

```
Full report can be seen in `reports/TestResults_TestGTFSPathwaysIntegration_2023-08-08_16-54-41.html` location


