### PR TITLE
Fix JSON formatting

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -68,6 +68,36 @@ jobs:
         run: |
           coverage report --fail-under=85
 
+      - name: Generate coverage badge
+        run: |
+          pip install coverage-badge
+          mkdir -p badge-out
+          coverage-badge -f -o badge-out/coverage.svg
+
+      - name: Publish coverage badge to badges branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          cp badge-out/coverage.svg /tmp/coverage.svg
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin badges || true
+          if git show-ref --verify --quiet refs/remotes/origin/badges; then
+            git checkout badges
+          else
+            git checkout --orphan badges
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+          cp /tmp/coverage.svg coverage.svg
+          git add coverage.svg
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: update coverage badge"
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:badges
+          else
+            echo "No badge changes to commit."
+          fi
+
       - name: Upload report to Azure
         uses: LanceMcCarthy/Action-AzureBlobUpload@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ test_report.html
 integration_test_report.html
 /.vscode
 test_results
+.idea

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TDEI-python-gtfs-pathways-validation
 
-[![Unit Tests](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/actions/workflows/unit_tests.yaml/badge.svg)](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/actions/workflows/unit_tests.yaml)
-![Coverage](https://raw.githubusercontent.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/badges/coverage.svg)
-[![gtfs-canonical-validator](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-pathways-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Egtfs-canonical-validator%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=gtfs-canonical-validator&color=blue)](https://pypi.org/project/gtfs-canonical-validator/)
-[![python-ms-core](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-pathways-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Epython-ms-core%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=python-ms-core&color=blue)](https://pypi.org/project/python-ms-core/)
+[![Unit Tests](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/actions/workflows/unit_tests.yaml/badge.svg?cacheSeconds=60)](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/actions/workflows/unit_tests.yaml)
+![Coverage](https://raw.githubusercontent.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/badges/coverage.svg?cacheSeconds=60)
+[![gtfs-canonical-validator](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-pathways-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Egtfs-canonical-validator%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=gtfs-canonical-validator&color=blue&cacheSeconds=60)](https://pypi.org/project/gtfs-canonical-validator/)
+[![python-ms-core](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-pathways-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Epython-ms-core%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=python-ms-core&color=blue&cacheSeconds=60)](https://pypi.org/project/python-ms-core/)
 
 ## Introduction 
 Service to Validate the GTFS pathways file that is uploaded. At the moment, the service does the following:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # TDEI-python-gtfs-pathways-validation
 
+[![Unit Tests](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/actions/workflows/unit_tests.yaml/badge.svg)](https://github.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/actions/workflows/unit_tests.yaml)
+![Coverage](https://raw.githubusercontent.com/TaskarCenterAtUW/TDEI-python-gtfs-pathways-validation/badges/coverage.svg)
+[![gtfs-canonical-validator](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-pathways-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Egtfs-canonical-validator%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=gtfs-canonical-validator&color=blue)](https://pypi.org/project/gtfs-canonical-validator/)
+[![python-ms-core](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FTaskarCenterAtUW%2FTDEI-python-gtfs-pathways-validation%2Fmain%2Frequirements.txt&search=%28%3Fm%29%5Epython-ms-core%3D%3D%28%5B%5E%5Cr%5Cn%5D%2B%29&replace=%241&label=python-ms-core&color=blue)](https://pypi.org/project/python-ms-core/)
+
 ## Introduction 
 Service to Validate the GTFS pathways file that is uploaded. At the moment, the service does the following:
 - Listens to the topic which is mentioned in `.env` file for any new message (that is triggered when a file is uploaded), example  `UPLOAD_TOPIC=gtfs-pathways-upload` 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ jsonschema==4.17.3
 httpx~=0.27.0
 coverage
 html_testRunner==1.2.1
-gtfs-canonical-validator==0.0.8
+gtfs-canonical-validator==0.0.9
 uvicorn==0.20.0

--- a/src/gtfs_pathways_validation.py
+++ b/src/gtfs_pathways_validation.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import logging
 import traceback
+import json
 from pathlib import Path
 from typing import Union, Any
 from .config import Settings
@@ -47,19 +48,22 @@ class GTFSPathwaysValidation:
             result = pathways_validator.validate()
 
             is_valid = result.status
+            validation_errors = self.parse_validation_errors(result.error)
+            validation_info = self.parse_validation_errors(result.info)
             if result.error is not None:
-                validation_message = str(result.error)
-                logger.error(f' Error While Validating File: {str(result.error)}')
+                validation_message = self.format_validation_errors(validation_errors)
+                logger.error(f' Error While Validating File: {validation_message}')
 
-            if isinstance(result.error, list) and result.error is not None:
-                for error in result.error[:]:
+            if isinstance(validation_errors, list):
+                for error in validation_errors[:]:
                     # change some smaller errors to warnings instead to relax the strict validation MD gives us
                     if error['code'] in CHANGE_ERROR_TO_WARNING:
-                        if result.info is None:
-                            result.info = []
+                        if not isinstance(validation_info, list):
+                            validation_info = []
 
-                        result.info.append(error)
-                        result.error.remove(error)
+                        validation_info.append(error)
+                        result.info = validation_info
+                        validation_errors.remove(error)
                         continue
 
                     # these are error codes from MD that relate to pathways that are fatal
@@ -89,17 +93,34 @@ class GTFSPathwaysValidation:
                                 continue
 
                 # if all errors have been downgraded to warnings, mark us as a success
-                if len(result.error) == 0:
+                if len(validation_errors) == 0:
                     is_valid = True
 
-                if result.error is not None:
-                    validation_message = str(result.error)
-                    logger.error(f' Error While Validating File: {str(result.error)}')
+                if validation_errors is not None:
+                    validation_message = self.format_validation_errors(validation_errors)
+                    logger.error(f' Error While Validating File: {validation_message}')
             GTFSPathwaysValidation.clean_up(os.path.dirname(downloaded_file_path))
         else:
             logger.error(f' Failed to validate because unknown file format')
 
         return is_valid, validation_message
+
+    @staticmethod
+    def parse_validation_errors(errors: Any) -> Any:
+        if isinstance(errors, str):
+            try:
+                return json.loads(errors)
+            except json.JSONDecodeError:
+                return errors
+
+        return errors
+
+    @staticmethod
+    def format_validation_errors(errors: Any) -> str:
+        if isinstance(errors, str):
+            return errors
+
+        return json.dumps(errors, default=str)
 
     # Downloads the file to local folder of the server
     # file_upload_path is the fullUrl of where the

--- a/tests/unit_tests/test_gtfs_pathways_validation.py
+++ b/tests/unit_tests/test_gtfs_pathways_validation.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import unittest
@@ -587,6 +588,31 @@ class TestGTFSPathwaysValidationOther(unittest.TestCase):
         # Assert
         self.assertFalse(is_valid)
 
+    def test_parse_validation_errors_reads_validator_json_text(self):
+        # Arrange
+        errors = '[{"code": "INVALID_FIELD", "sampleNotices": []}]'
+
+        # Act
+        validation_errors = GTFSPathwaysValidation.parse_validation_errors(errors)
+
+        # Assert
+        self.assertEqual(validation_errors, [{'code': 'INVALID_FIELD', 'sampleNotices': []}])
+
+    def test_format_validation_errors_serializes_errors_as_json_text(self):
+        # Arrange
+        errors = [{'code': 'INVALID_FIELD', 'sampleNotices': [{'fieldName': 'invalid_field'}]}]
+
+        # Act
+        validation_message = GTFSPathwaysValidation.format_validation_errors(errors)
+
+        # Assert
+        self.assertEqual(
+            json.loads(validation_message),
+            [{'code': 'INVALID_FIELD', 'sampleNotices': [{'fieldName': 'invalid_field'}]}]
+        )
+        self.assertNotIn("'", validation_message)
+        self.assertFalse(validation_message.startswith('"'))
+
     @patch('src.gtfs_pathways_validation.CanonicalValidator')
     def test_is_pathways_valid_with_errors(self, mock_canonical_validator):
         # Arrange
@@ -606,6 +632,53 @@ class TestGTFSPathwaysValidationOther(unittest.TestCase):
         # Assert
         self.assertFalse(is_valid)
         self.assertIn('INVALID_FIELD', validation_message)
+        self.assertEqual(json.loads(validation_message), mock_result.error)
+
+    @patch('src.gtfs_pathways_validation.CanonicalValidator')
+    def test_is_pathways_valid_with_json_string_errors(self, mock_canonical_validator):
+        # Arrange
+        validation_errors = [
+            {'code': 'INVALID_FIELD', 'sampleNotices': [{'fieldName': 'invalid_field', 'filename': 'pathways_data'}]}
+        ]
+        mock_result = MagicMock()
+        mock_result.status = False
+        mock_result.error = json.dumps(validation_errors)
+        mock_canonical_validator.return_value.validate.return_value = mock_result
+
+        expected_downloaded_file_path = f'{DOWNLOAD_FILE_PATH}/{SUCCESS_FILE_NAME}'
+        self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
+
+        # Act
+        is_valid, validation_message = self.validator.is_gtfs_pathways_valid()
+
+        # Assert
+        self.assertFalse(is_valid)
+        self.assertFalse(validation_message.startswith('"'))
+        self.assertEqual(json.loads(validation_message), validation_errors)
+
+    @patch('src.gtfs_pathways_validation.CanonicalValidator')
+    def test_is_pathways_valid_with_json_string_info(self, mock_canonical_validator):
+        # Arrange
+        validation_errors = [
+            {'code': 'block_trips_with_overlapping_stop_times',
+             'sampleNotices': [{'fieldName': 'invalid_field', 'filename': 'pathways_data'}]}
+        ]
+        mock_result = MagicMock()
+        mock_result.status = False
+        mock_result.error = json.dumps(validation_errors)
+        mock_result.info = '[]'
+        mock_canonical_validator.return_value.validate.return_value = mock_result
+
+        expected_downloaded_file_path = f'{DOWNLOAD_FILE_PATH}/{SUCCESS_FILE_NAME}'
+        self.validator.download_single_file = MagicMock(return_value=expected_downloaded_file_path)
+
+        # Act
+        is_valid, validation_message = self.validator.is_gtfs_pathways_valid()
+
+        # Assert
+        self.assertTrue(is_valid)
+        self.assertEqual(validation_message, '[]')
+        self.assertEqual(mock_result.info, validation_errors)
 
     @patch('src.gtfs_pathways_validation.CanonicalValidator')
     def test_is_pathways_valid_to_convert_error_to_warning(self, mock_canonical_validator):


### PR DESCRIPTION
## Dev Board Ticket

- https://dev.azure.com/TDEI-UW/TDEI/_workitems/edit/3657

## Changes
- Fixed validation error output so job messages emit parseable JSON with double-quoted keys and strings.
- Added parsing for gtfs-canonical-validator==0.0.9 JSON-string error and info responses before applying validation logic.
- Prevented downgraded warning handling from failing when result.info is returned as a JSON string.
- Added regression tests for JSON-string validator responses and JSON-formatted validation messages.

## Testing
```
python -m coverage run --source=src -m unittest discover -s tests/unit_tests
...........
........

OK
Ran 65 tests in 74.497s
```